### PR TITLE
Add a path to fix a bug in the ZmqServer::Close method

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,12 @@ WORKDIR /usr/local/src
 RUN git clone https://github.com/slaclab/rogue.git -b v4.5.1
 WORKDIR rogue
 
+# Apply ZmqServerClose patch, to solve the problem
+# reported in ESCRYODET-471
+RUN mkdir -p patches
+ADD patches/* patches/
+RUN git apply patches/ZmqServerClose.patch
+
 RUN mkdir build
 WORKDIR build
 RUN cmake -DCMAKE_BUILD_TYPE=Release -DROGUE_INSTALL=local ..

--- a/patches/ZmqServerClose.patch
+++ b/patches/ZmqServerClose.patch
@@ -1,0 +1,14 @@
+diff --git a/src/rogue/interfaces/ZmqServer.cpp b/src/rogue/interfaces/ZmqServer.cpp
+index 719e0f6a..345c27c0 100755
+--- a/src/rogue/interfaces/ZmqServer.cpp
++++ b/src/rogue/interfaces/ZmqServer.cpp
+@@ -92,8 +92,8 @@ void rogue::interfaces::ZmqServer::close() {
+       threadEn_ = false;
+       zmq_close(this->zmqPub_);
+       zmq_close(this->zmqRep_);
+-      zmq_ctx_destroy(this->zmqCtx_);
+-      thread_->join();
++      //zmq_ctx_destroy(this->zmqCtx_);
++      //thread_->join();
+    }
+ }


### PR DESCRIPTION
which was making the Rogue's Root.close() method to hang as reported here:

https://jira.slac.stanford.edu/browse/ESCRYODET-471
