### PR TITLE
Update Rogue to version v4.10.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN pip3 install PyYAML Pyro4 parse click pyzmq packaging jsonpickle sqlalchemy 
 
 # Install Rogue (An specific point in the the pre-release branch)
 WORKDIR /usr/local/src
-RUN git clone https://github.com/slaclab/rogue.git -b v4.10.1
+RUN git clone https://github.com/slaclab/rogue.git -b v4.10.6
 WORKDIR rogue
 
 # Apply patches


### PR DESCRIPTION
This version of Rogue has some bug fixes, including the one we saw in pysmurf described here:
https://jira.slac.stanford.edu/browse/ESCRYODET-600