### PR TITLE
Update smurf-base base image to version R1.1.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tidair/smurf-base:R1.1.0
+FROM tidair/smurf-base:R1.1.1
 
 # Install system tools
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
This version fixes the bug of the missing `/home/cryo` directory.