### PR TITLE
Update rogue to version v4.11.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN pip3 install PyYAML Pyro4 parse click pyzmq packaging jsonpickle sqlalchemy 
 
 # Install Rogue (An specific point in the the pre-release branch)
 WORKDIR /usr/local/src
-RUN git clone https://github.com/slaclab/rogue.git -b v4.11.0
+RUN git clone https://github.com/slaclab/rogue.git -b v4.11.2
 WORKDIR rogue
 
 # Apply patches


### PR DESCRIPTION
This version fixes a memory leak as described here: https://jira.slac.stanford.edu/browse/ESCRYODET-640