### PR TITLE
Update rogue to version v4.11.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN pip3 install PyYAML Pyro4 parse click pyzmq packaging jsonpickle sqlalchemy 
 
 # Install Rogue (An specific point in the the pre-release branch)
 WORKDIR /usr/local/src
-RUN git clone https://github.com/slaclab/rogue.git -b v4.11.7
+RUN git clone https://github.com/slaclab/rogue.git -b v4.11.8
 WORKDIR rogue
 
 # Apply patches


### PR DESCRIPTION
This version of rogue fixes https://jira.slac.stanford.edu/browse/ESROGUE-497 and https://jira.slac.stanford.edu/browse/ESROGUE-498