### PR TITLE
Upgrading smurf-base to R2.0.0 which upgrades Ubuntu 18.04->20.04.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tidair/smurf-base:R1.1.1
+FROM tidair/smurf-base:R2.0.0
 
 # Install system tools
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
Upgrades smurf-base to [R2.0.0](https://github.com/slaclab/smurf-base-docker/releases/tag/R2.0.0) which upgrades Ubuntu 18.04->20.04.  Needed because GitHub is no longer supporting Ubuntu 18.04 (https://github.com/slaclab/pysmurf/issues/764), so we must upgrade to 20.04 (the next LTS version) in order to be able to build new SMuRF software releases.
Will also upgrade python3 version used in the dockers to python 3.8.10.