### PR TITLE
Require PyDM version 1.18.2 and pyqt5 version 5.15 to fix server gui crash and PyQtGraph Runtime warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,11 @@ RUN apt-get update && apt-get install -y \
  && rm -rf /var/lib/apt/lists/*
 
 # PIP Packages
-RUN pip3 install PyYAML Pyro4 parse click pyzmq packaging jsonpickle sqlalchemy serial pydm
+RUN pip3 install PyYAML Pyro4 parse click pyzmq packaging jsonpickle sqlalchemy serial
+# Server gui crashing for PyDM versions >= 1.19.0.
+RUN pip3 install pydm==1.18.2
+# Upgrade pyqt5
+RUN pip3 install pyqt5==5.15
 
 # Install Rogue (An specific point in the the pre-release branch)
 WORKDIR /usr/local/src


### PR DESCRIPTION
To fix server gui crashing  and get rid of a PyQtGraph Runtime warning which are happening after https://github.com/slaclab/smurf-rogue-docker/pull/26 which upgraded Ubuntu from 18.04 to 20.04 (see https://github.com/slaclab/pysmurf/issues/768).  Closes issue https://github.com/slaclab/smurf-rogue-docker/issues/27.  Tested by building the smurf-rogue docker locally and confirming pydm version now 1.18.2 and Runtime warning (when importing the pydm module in python3) resolved.