### PR TITLE
Downgrade pydm to v1.17.0 to match working SO streamer version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -y \
 # PIP Packages
 RUN pip3 install PyYAML Pyro4 parse click pyzmq packaging jsonpickle sqlalchemy serial
 # Server gui crashing for PyDM versions >= 1.19.0.
-RUN pip3 install pydm==1.18.2
+RUN pip3 install pydm==1.17.0
 # Upgrade pyqt5
 RUN pip3 install pyqt5==5.15
 


### PR DESCRIPTION
Seeing strange behavior with new server dockers built on https://github.com/slaclab/smurf-rogue-docker/releases/tag/R2.9.1 which was built with pydm version 1.18.2. SO software stack seems to work fine with almost identical Dockerfile, but their last working dockers were built with pydm version 1.17.0.  Let's try if dropping down to that pydm version fixes the issues we're seeing.