### PR TITLE
Upgrade smurf-base version to R3.0.1 which upgrades Ubuntu to 22.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tidair/smurf-base:R2.0.0
+FROM tidair/smurf-base:R3.0.1
 
 # Install system tools
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
…instead of Ubuntu 20.04.